### PR TITLE
README.md: update cvt2utf examples usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ ___Examples:___
 
 * Changes all .txt files to UTF-8 encoding. Additionally, **removes BOMs** from utf_8_sig-encoded files: 
 
-    `cvt2utf "/path/to/your/repo" `
+    `cvt2utf convert "/path/to/your/repo" `
 
 * Changes all .php files to UTF-8 encoding. But, leaves unchanged those utf_8_sig-encoded files: 
 
-    `cvt2utf "/path/to/your/repo" -i php --skiputf`
+    `cvt2utf convert "/path/to/your/repo" -i php --skiputf`
 
 * Changes all .csv files to UTF-8 encoding. But leaves .txt files unchanged: 
 
      Since BOM are used by some applications (such as Microsoft Excel), we want to add BOM
 
-    `cvt2utf "/path/to/your/repo" -b -i csv -x txt`
+    `cvt2utf convert "/path/to/your/repo" -b -i csv -x txt`
 
     
 * Convert all .c and .cpp files to UTF-8 with BOMs. 
@@ -43,11 +43,11 @@ ___Examples:___
     
     Visual Studio may mandate BOM in source files. If BOMs are missing, then Visual Studio will unable to compile them.
 
-    `cvt2utf "/path/to/your/repo" -b -i c cpp -x txt`
+    `cvt2utf convert "/path/to/your/repo" -b -i c cpp -x txt`
     
 * Converts an individual file 
 
-    `cvt2utf "/path/to/your/repo/a.txt"`
+    `cvt2utf convert "/path/to/your/repo/a.txt"`
 
 * After manually verify the new UTF-8 files are correct, you can remove all .bak files
 
@@ -58,7 +58,7 @@ ___Examples:___
     
     Use the `--nobak` option with **extra caution**!
 
-    `cvt2utf "/path/to/your/repo" --nobak`
+    `cvt2utf convert "/path/to/your/repo" --nobak`
 
 * Display help information
 


### PR DESCRIPTION
I noticed that **cvt2utf** does not execute normally when the `convert` parameter is missing, please refer to the following two cases below:

- case 1: `cvt2utf "./" -i c --nobak -x txt` and `cvt2utf convert "./" -i c --nobak -x txt`
```
➜  /home/mi/xiaomi/test/cMemoryPool git:(master) cvt2utf "./" -i c --nobak -x txt
usage: cvt2utf [-h] [-v] {convert,cvt,cleanbak,cb} ...
cvt2utf: error: argument cmd: invalid choice: './' (choose from 'convert', 'cvt', 'cleanbak', 'cb')

➜  /home/mi/xiaomi/test/cMemoryPool git:(master) cvt2utf convert "./" -i c --nobak -x txt
INFO:Start working now!
INFO:The root folder is: ./.
INFO:Files with these extension names will be processed: {'c', 'txt'}
INFO:Files with these extension names will be ignored: {'txt', 'bak'}
INFO:Finished all.
```
- case 2: `cvt2utf "./"` and `cvt2utf convert "./"`
```
➜  /home/mi/xiaomi/test/cMemoryPool git:(master) cvt2utf "./"
usage: cvt2utf [-h] [-v] {convert,cvt,cleanbak,cb} ...
cvt2utf: error: argument cmd: invalid choice: './' (choose from 'convert', 'cvt', 'cleanbak', 'cb')

➜  /home/mi/xiaomi/test/cMemoryPool git:(master) cvt2utf convert "./"
INFO:Start working now!
INFO:The root folder is: ./.
INFO:Files with these extension names will be processed: {'txt'}
INFO:Files with these extension names will be ignored: {'bak'}
INFO:Finished all.
➜  /home/mi/xiaomi/test/cMemoryPool git:(master)
```

**So, this PR just updates cvt2utf examples usage, it will make it easier for the user.**

Signed-off-by: Junbo Zheng <3273070@qq.com>